### PR TITLE
Removed "response-content-disposition" from key in content_info_string…

### DIFF
--- a/wetransfer.py
+++ b/wetransfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Download WeTransfer files
@@ -10,24 +10,35 @@
 # DEPENDS       :pip install requests
 
 from urlparse import urlparse, parse_qs
-import requests, sys, json, re, getopt, sys
+import requests
+import sys
+import json
+import getopt
 
 DOWNLOAD_URL_PARAMS_PREFIX = "downloads/"
 CHUNK_SIZE = 1024
 
+
 def download(file_id, recipient_id, security_hash):
-    url = "https://www.wetransfer.com/api/v1/transfers/{0}/download?recipient_id={1}&security_hash={2}&password=&ie=false".format(file_id, recipient_id, security_hash)
+    url = "https://www.wetransfer.com/api/v1/transfers/{0}/download?recipient_id={1}&security_hash={2}&password=&ie=false".format(
+        file_id, recipient_id, security_hash)
     r = requests.get(url)
     download_data = json.loads(r.content)
 
     print "Downloading {0}...".format(url)
-    if download_data.has_key('direct_link'):
-        content_info_string = parse_qs(urlparse(download_data['direct_link']).query)['response-content-disposition'][0]
-        file_name = re.findall('filename="(.*?)"', content_info_string)[0].encode('ascii', 'ignore')
+    if 'direct_link' in download_data:
+        content_info_string = parse_qs(
+            urlparse(download_data['direct_link']).query)
+        file_name_data = content_info_string['filename']
+        file_name = file_name_data[0]
         r = requests.get(download_data['direct_link'], stream=True)
     else:
         file_name = download_data['fields']['filename']
-        r = requests.post(download_data['formdata']['action'], data=download_data["fields"], stream=True)
+        r = requests.post(
+            download_data['formdata']['action'],
+            data=download_data["fields"],
+            stream=True
+            )
 
     file_size = int(r.headers["Content-Length"])
     output_file = open(file_name, 'wb')
@@ -36,7 +47,10 @@ def download(file_id, recipient_id, security_hash):
         if chunk:
             output_file.write(chunk)
             output_file.flush()
-            sys.stdout.write('\r{0}% {1}/{2}'.format((counter * CHUNK_SIZE) * 100 / file_size, counter * CHUNK_SIZE, file_size))
+            sys.stdout.write(
+                '\r{0}% {1}/{2}'.format((counter * CHUNK_SIZE) * 100/file_size,
+                                        counter * CHUNK_SIZE,
+                                        file_size))
             counter += 1
 
     sys.stdout.write('\r100% {0}/{1}\n'.format(file_size, file_size))
@@ -51,11 +65,12 @@ def extract_params(url):
     params = url.split(DOWNLOAD_URL_PARAMS_PREFIX)[1].split('/')
     [file_id, recipient_id, security_hash] = ['', '', '']
     if len(params) > 2:
-        #The url is similar to https://www.wetransfer.com/downloads/XXXXXXXXXX/YYYYYYYYY/ZZZZZZZZ
+        # The url is similar to
+        # https://www.wetransfer.com/downloads/XXXXXXXXXX/YYYYYYYYY/ZZZZZZZZ
         [file_id, recipient_id, security_hash] = params
     else:
-        #The url is similar to https://www.wetransfer.com/downloads/XXXXXXXXXX/ZZZZZZZZ
-        #In this case we have no recipient_id
+        # The url is similar to https://www.wetransfer.com/downloads/XXXXXXXXXX/ZZZZZZZZ
+        # In this case we have no recipient_id
         [file_id, security_hash] = params
 
     return [file_id, recipient_id, security_hash]
@@ -66,6 +81,7 @@ def extract_url_redirection(url):
         Follow the url redirection if necesary
     """
     return requests.get(url).url
+
 
 def usage():
     print """
@@ -91,7 +107,7 @@ def main(argv):
 
         if len(argv) == 0:
             usage()
-            
+
         if argv[0].find('http') == 0:
             url = argv[0]
 


### PR DESCRIPTION
I have removed the "response-content-disposition" because there is not anymore in the API. To find the file name I have changed to `file_name_data = content_info_string['filename']` because the regedix it was not working, I think that is an easier way to find it. 

I also change some format to complain with PEP8, now is easier to read.
